### PR TITLE
Fixed neutron-l3-agent dependancy error on Ubuntu

### DIFF
--- a/pillar_root/Ubuntu.sls
+++ b/pillar_root/Ubuntu.sls
@@ -262,6 +262,7 @@ resources:
             - "neutron-l3-agent"
             - "neutron-dhcp-agent"
             - "neutron-metadata-agent"
+            - "python-neutron-fwaas"
             - "python-neutronclient"
             - "conntrack"
         services:


### PR DESCRIPTION
Fixes issue #23

Added `python-neutron-fwaas` to the list of pkgs to be installed.
